### PR TITLE
Add handbook instructions and project TODO

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# Handbook Retrieval Agent
+
+## 1. Purpose  
+This agent empowers end-users to query a company handbook (SOPs, policies, FAQs) and receive:  
+- The most relevant Standard Operating Procedure (SOP)  
+- Any cross-referenced policies or guidelines  
+- Direct links back to the original document sections  
+
+## 2. High-Level Workflow  
+1. **Document Ingestion**  
+   - Load all `.md` files from the handbook folder.  
+2. **Classification & Tagging**  
+   - Detect document type: SOP, Policy, FAQ, etc.  
+   - Extract metadata: `title`, `section_headers`, `doc_type`, `tags`.  
+3. **Chunking**  
+   - Split each document into semantic chunks (~200–300 words or logical subsections).  
+   - Assign each chunk its parent document’s metadata.  
+4. **Embedding**  
+   - Use a transformer-based embedding model (e.g. OpenAI’s embeddings or Sentence-Transformers) to vectorize each chunk and each title.  
+5. **Indexing**  
+   - Store vectors in a vector database (e.g. Pinecone, Weaviate), alongside metadata.  
+6. **Query Handling**  
+   - **Title match**: embed the user query and perform fast nearest-neighbour search among *titles* to identify the primary SOP.  
+   - **Deep dive**: within the chosen SOP, re-embed and search its chunks to extract precise instructions.  
+   - **Cross-policy retrieval**: use metadata tags from the primary SOP to fetch related policy chunks.  
+7. **Response Assembly**  
+   - Compile a structured response:  
+     1. **SOP summary** (from top-scoring chunk)  
+     2. **Related policies** (list with short excerpts)  
+     3. **Links** to full SOP and policy files with section anchors  
+
+## 3. Metadata Schema  
+| Field             | Type   | Description                                 |
+|-------------------|--------|---------------------------------------------|
+| `doc_id`          | string | Unique ID (e.g. filename without extension) |
+| `doc_type`        | string | SOP / Policy / FAQ / …                      |
+| `title`           | string | Document title                              |
+| `section`         | string | Section/header text                         |
+| `tags`            | array  | Keywords for cross-reference                 |
+| `source_path`     | string | Relative file path                          |
+| `anchor`          | string | Markdown anchor for the section             |
+
+## 4. Tools & Libraries  
+- **Markdown parsing**: `python-markdown` or `mistune`  
+- **Embedding**: OpenAI Embeddings or HuggingFace Sentence-Transformers  
+- **Vector DB**: Pinecone, Weaviate or Elasticsearch + KNN plugin  
+- **Backend**: FastAPI / Flask for query APIs  
+- **Monitoring**: Prometheus + Grafana (latency, error-rates)  
+
+## 5. Performance & Quality  
+- **Chunk size tuning**: balance between context richness and vector noise.  
+- **Reranking**: optionally apply a fine-tuned cross-encoder on top K candidates for precision.  
+- **Logging**: record query → chunks → final selection for audit.  
+
+## 6. Extension Points  
+- Support for additional document formats (PDF, Word).  
+- Multilingual embedding & retrieval.  
+- Role-based access control (restrict certain SOPs).  
+
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,48 @@
+# 📋 Project To-Do
+
+1. **Document Prep & Ingestion**  
+   - [ ] Audit existing `.md` files; ensure consistent front-matter (title, type).  
+   - [ ] Write ingestion script to traverse handbook folder.  
+
+2. **Metadata & Classification**  
+   - [ ] Define and implement metadata schema.  
+   - [ ] Build doc-type classifier (rules or lightweight ML).  
+
+3. **Chunking Engine**  
+   - [ ] Develop parser to split by headers/paragraphs (~200–300 words).  
+   - [ ] Attach metadata to each chunk.  
+
+4. **Embedding Pipeline**  
+   - [ ] Select embedding model; prototype on sample chunks.  
+   - [ ] Write batch embedding script.
+
+5. **Vector Database Setup**  
+   - [ ] Provision vector DB instance (Pinecone/Weaviate).  
+   - [ ] Create index with metadata fields.
+
+6. **Search & Retrieval**  
+   - [ ] Implement title-level semantic search.  
+   - [ ] Implement chunk-level semantic search within selected SOP.  
+   - [ ] Build policy cross-reference using shared tags.
+
+7. **API & Response Formatting**  
+   - [ ] Define API schema (query → structured JSON response).  
+   - [ ] Assemble response templates (SOP excerpt, related policies, links).
+
+8. **Testing & QA**  
+   - [ ] Write unit tests for ingestion, chunking, metadata.  
+   - [ ] Conduct integration tests: sample queries → expected docs.  
+   - [ ] Solicit user feedback on relevance & clarity.
+
+9. **Deploy & Monitor**  
+   - [ ] Containerise services (Docker).  
+   - [ ] Deploy to staging; set up monitoring dashboards.  
+   - [ ] Roll out to production; schedule regular embedding refresh.
+
+10. **Future Enhancements**  
+   - [ ] Add cross-encoder reranking.  
+   - [ ] Integrate role-based access controls.  
+   - [ ] Expand to multilingual support.  
+
+> _Tip: Tackle items in vertical slices (end-to-end MVP → incremental refinements)._  
+


### PR DESCRIPTION
## Summary
- add Agent instructions for handbook retrieval
- outline project TODO list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68643426143483338820f1329c6ffd0f